### PR TITLE
Add link to con/tents repository in README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -16,4 +16,5 @@ Some are also listed in the issues of the [con/ceptualization](https://github.co
 
 ## Quick Links
 - :computer: [centerforopenneuroscience.org](http://centerforopenneuroscience.org)
+- 📑[con/tents](https://github.com/con/tents)
 - :ambulance: [con/upptime](https://github.com/con/upptime/)


### PR DESCRIPTION
Sometimes I have trouble finding what I'm looking for on the org

The GitHub repos tab doesn't allow sorting by certain things and is very paginated

This helps me, hope it helps others